### PR TITLE
Quaff function to detect filepath vs buffer inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,8 +81,12 @@ function quaff(input, protocol, callback) {
 
       fs.read(fd, new Buffer(512), 0, 512, 0, function(err, bytes, buffer) {
           if (bytes.length < 300)
-              return callback(new Error('File too small'));
-          action(buffer, callback);
+              err = err || new Error('File too small');
+
+          fs.close(fd, function(closeErr) {
+              if (err || closeErr) return callback(err || closeErr);
+              action(buffer, callback);
+          });
       });
   });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,20 @@ tape('[KML BOM] Sniffing file: should return kml filetype and omnivore protocol'
 				});
     });
 });
+tape('[KML Valid] quaff and sniff', function(assert) {
+		filesniffer.quaff(testData + '/data/kml/1week_earthquake.kml', function(err, result) {
+				assert.ifError(err, 'quaffed valid kml');
+				assert.equal(result, 'kml', 'smells right');
+				assert.end();
+		});
+});
+tape('[KML Valid] quaff and waft', function(assert) {
+		filesniffer.quaff(testData + '/data/kml/1week_earthquake.kml', true, function(err, result) {
+				assert.ifError(err, 'quaffed valid kml');
+				assert.equal(result, 'omnivore:', 'smells right');
+				assert.end();
+		});
+});
 tape('[GeoJson] Sniffing file: should return geojson filetype and omnivore protocol', function(assert) {
 		var filepath = testData + '/data/geojson/DC_polygon.geo.json';
     var expectedFiletype = 'geojson';
@@ -256,6 +270,22 @@ tape('[tilejson Invalid] Sniffing file: should return error', function(assert) {
 				});
     });
 });
+tape('[tilejson Invalid] quaff and sniff', function(assert) {
+		filesniffer.quaff(path.resolve('./test/data/invalid.tilejson'), function(err, result) {
+				assert.ok(err instanceof Error);
+				assert.equal(err.message, 'Unknown filetype.');
+				assert.equal('EINVALID', err.code);
+				assert.end();
+		});
+});
+tape('[tilejson Invalid] quaff and waft', function(assert) {
+		filesniffer.quaff(path.resolve('./test/data/invalid.tilejson'), true, function(err, result) {
+				assert.ok(err instanceof Error);
+				assert.equal(err.message, 'Unknown filetype.');
+				assert.equal('EINVALID', err.code);
+				assert.end();
+		});
+});
 tape('[serialtiles] Sniffing file: should return serialtiles filetype and serialtiles protocol', function(assert) {
     var filepath = path.resolve('./test/data/valid-serialtiles.gz');
     var expectedFiletype = 'serialtiles';
@@ -374,4 +404,11 @@ tape('[Not Buffer object] Passing in invalid parameter: should return error', fu
 						assert.end();
 				});
     });
+});
+tape('[No such file] empty gulp', function(assert) {
+		filesniffer.quaff(path.resolve('./test/data/fake'), function(err, result) {
+				assert.ok(err instanceof Error);
+				assert.equal('ENOENT', err.code);
+				assert.end();
+		});
 });


### PR DESCRIPTION
Quaff:

> to drink (something, especially an alcoholic drink) heartily.

I think this is fitting name for a function that _actually ingests_ a little bit of your file before telling you what its type/protocol is. Although this does imply a "drink first, smell later" mentality that I don't suggest taking in daily life.

@GretaCB any objection? If not I'll write tests and merge.

refs #10 
