### PR TITLE
Exit codes + quaffing for executables

### DIFF
--- a/bin/mapbox-file-protocol.js
+++ b/bin/mapbox-file-protocol.js
@@ -1,19 +1,13 @@
 #!/usr/bin/env node
 
 var filesniffer = require('..');
-var fs = require('fs');
 var path = require('path');
 var filepath = path.resolve(process.argv[2]);
 
-fs.open(filepath, 'r', function(err, fd) {
-    if (err) return console.error(err);
-    var buf = new Buffer(512);
-    fs.read(fd, buf, 0, 512, 0, function(err, bytes, buffer) {
-        if (bytes.length < 300)
-          return console.error(new Error('File too small'));
-        filesniffer.waft(buffer, function(err, protocol) {
-            if (err) return console.error(err);
-            console.log(protocol);
-        });
-    });
+filesniffer.quaff(filepath, true, function(err, protocol) {
+    if (err) {
+        console.error(err.message);
+        process.exit(err.code === 'EINVALID' ? 3 : 1);
+    }
+    console.log(protocol);
 });

--- a/bin/mapbox-file-type.js
+++ b/bin/mapbox-file-type.js
@@ -1,19 +1,13 @@
 #!/usr/bin/env node
 
 var filesniffer = require('..');
-var fs = require('fs');
 var path = require('path');
 var filepath = path.resolve(process.argv[2]);
 
-fs.open(filepath, 'r', function(err, fd) {
-    if (err) return console.error(err);
-    var buf = new Buffer(512);
-    fs.read(fd, buf, 0, 512, 0, function(err, bytes, buffer) {
-        if (bytes.length < 300)
-          return console.error(new Error('File too small'));
-        filesniffer.sniff(buffer, function(err, type) {
-            if (err) return console.error(err);
-            console.log(type);
-        });
-    });
+filesniffer.quaff(filepath, function(err, type) {
+    if (err) {
+        console.error(err.message);
+        process.exit(err.code === 'EINVALID' ? 3 : 1);
+    }
+    console.log(type);
 });


### PR DESCRIPTION
If the error is expected (`EINVALID`), exit 3. If the error is unexpected, exit 1. Also simplify these executables by using the quaff function.
