### PR TITLE
VRT validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ function sniff(buffer, callback) {
     if (head.indexOf('\"tilejson\":') !== -1){
         return callback(null, 'tilejson');
     }
+    if (head.indexOf('<VRTDataset') !== -1){
+        return callback(null, 'vrt');
+    }
     // check for unzipped .shp
     if (buffer.readUInt32BE(0) === 9994) {
         return callback(null, 'shp');
@@ -58,6 +61,7 @@ function waft(buffer, callback) {
         shp: 'omnivore:',
         zip: 'omnivore:',
         tif: 'omnivore:',
+        vrt: 'omnivore:',
         geojson: 'omnivore:',
         kml: 'omnivore:',
         gpx: 'omnivore:',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,7 +34,6 @@ tape('[KML] Sniffing file: should return kml filetype and omnivore protocol', fu
             assert.end();
         });
     });
-
 });
 tape('[KML BOM] Sniffing file: should return kml filetype and omnivore protocol', function(assert) {
     var filepath = path.resolve('./test/data/bom.kml');
@@ -74,6 +73,48 @@ tape('[KML Valid] quaff and sniff', function(assert) {
 tape('[KML Valid] quaff and waft', function(assert) {
     filesniffer.quaff(testData + '/data/kml/1week_earthquake.kml', true, function(err, result) {
         assert.ifError(err, 'quaffed valid kml');
+        assert.equal(result, 'omnivore:', 'smells right');
+        assert.end();
+    });
+});
+tape('[VRT] Sniffing file: should return vrt filetype and omnivore protocol', function(assert) {
+    var filepath = testData + '/data/vrt/sample.vrt';
+    var expectedFiletype = 'vrt';
+    var buffer;
+    try {
+        fs.statSync(filepath);
+        buffer = new Buffer(512);
+        var fd = fs.openSync(filepath, 'r');
+        fs.readSync(fd, buffer, 0, 512, 0);
+        fs.closeSync(fd);
+    } catch (err) {
+        return assert.end(err);
+    }
+    filesniffer.sniff(buffer, function(err, filetype) {
+        if (err) return assert.end(err);
+        assert.ok(err === null);
+        try {
+            assert.equal(filetype, expectedFiletype);
+        } catch (err) {
+            return assert.end(err);
+        }
+        filesniffer.waft(buffer, function(err, protocol) {
+            assert.ifError(err);
+            assert.equal(protocol, 'omnivore:');
+            assert.end();
+        });
+    });
+});
+tape('[VRT Valid] quaff and sniff', function(assert) {
+    filesniffer.quaff(testData + '/data/vrt/sample.vrt', function(err, result) {
+        assert.ifError(err, 'quaffed valid vrt');
+        assert.equal(result, 'vrt', 'smells right');
+        assert.end();
+    });
+});
+tape('[VRT Valid] quaff and waft', function(assert) {
+    filesniffer.quaff(testData + '/data/vrt/sample.vrt', true, function(err, result) {
+        assert.ifError(err, 'quaffed valid vrt');
         assert.equal(result, 'omnivore:', 'smells right');
         assert.end();
     });


### PR DESCRIPTION
Basic detection for VRT sources from header.

`"Basic validation"` because it doesn't actually use `gdal` to open and check internal values. It simply checks for `<VRTDataset` string in the header.

cc @rclark 