### PR TITLE
Cleaner way to check for ustar

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,7 @@ function sniff(buffer, callback) {
     zlib.gunzip(buffer, function(err, output) {
         if (err) return callback(invalid('Unknown filetype'));
         //check for tm2z
-        if (output.toString().slice(257, 262) === 'ustar' ||
-          output.toString().slice(256, 261) === 'ustar') return callback(null, 'tm2z');
+        if (output.toString('ascii', 257, 262) === 'ustar') return callback(null, 'tm2z');
         //check for serial tiles
         head = output.slice(0,50);
         if (head.toString().indexOf('JSONBREAKFASTTIME') === 0) return callback(null, 'serialtiles');


### PR DESCRIPTION
Whether the file has an extended header or not, using `toString('ascii', 257, 262)` will detect `ustar`.