### PR TITLE
Add an eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-unstyled"
+}

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function sniff(buffer, callback) {
         return callback(invalid('Unknown filetype'));
     }
 
-    head = header.substring(0,100);
+    var head = header.substring(0,100);
     if (head.indexOf('SQLite format 3') === 0){
         return callback(null, 'mbtiles');
     }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "tape": "3.0.x",
     "coveralls": "~2.11.1",
     "istanbul": "~0.3.0",
-    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.1.0-04476a347181c625e3356e2e56f8e2f43e134260.tgz"
+    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.1.0-04476a347181c625e3356e2e56f8e2f43e134260.tgz",
+    "eslint": "~1.00.0",
+    "eslint-config-unstyled": "^1.1.0"
   },
   "scripts": {
-    "test": "tape test/*.js",
+    "test": "eslint index.js lib && tape test/*.js",
     "coverage": "istanbul cover tape test/*.test.js && coveralls < ./coverage/lcov.info"
   },
   "bin": {


### PR DESCRIPTION
This brings up a real problem: there's a global leak of the `head` variable in multiple places in mapbox-file-sniff. Who'd be the best to fix this and update the dependents?