### PR TITLE
Create .npmignore, republish to save 25 MB

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.travis.yml
+mapbox-file-sniff.jpg


### PR DESCRIPTION
This adds a `.npmignore` file. This will automatically ignore the root image, the .travis.yml, and the test directory. The idea here is to avoid publishing potentially large data that is unneeded for `npm --production` installs. After this is merged we should republish a new version of mapbox-file-sniff because currently the published version has a 25 MB `ne_10m_admin_0_countries_lakes.geojson` inside the test/data directory. This is not checked into git but must have been in that folder on the harddrive of the person that last published `mapbox-file-sniff`.