### PR TITLE
add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.travis.yml
+mapbox-file-sniff.jpg


### PR DESCRIPTION
This should resolve #56 by creating a new 0.5.x branch from v0.5.3 and adding the npmignore that is now in the 1.0.x release.

Can someone confirm these are the proper next steps (since this will be a new git tag, but for an older version):

* merge into 0.5.x branch
* update package.json & changelog
* push directly to 0.5.x branch
* git tag -a v0.5.4 -m 'v0.5.4'
* npm publish (should publish the old version - will this be considered latest accidentally?)

cc @springmeyer @GretaCB 