### PR TITLE
catch zero byte file

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function fromFile(file, callback) {
         if (err) return callback(err);
         fs.fstat(fd, function(err, stats) {
             if (err) return callback(err);
+            if (stats.size === 0) return callback(invalid('File is zero bytes.'));
             var size = stats.size < 512 ? stats.size : 512;
             fs.read(fd, new Buffer(size), 0, size, 0, function(err, bytes, buffer) {
                 if (bytes <= 2)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,6 +52,16 @@ tape('error: small file', function(assert) {
         assert.end();
     });
 });
+tape('error: zero byte file', function(assert) {
+    var filepath = path.resolve('./test/data/empty-shapefile/empty.shp');
+    assert.notOk(Buffer.isBuffer(filepath));
+    sniffer.fromFile(filepath, function(err, result) {
+        assert.ok(err);
+        assert.equal(err.message, 'File is zero bytes.', 'expected error message');
+        assert.equal(err.code, 'EINVALID', 'expected error code');
+        assert.end();
+    });
+});
 
 tape('[KML] success: file path', function(assert) {
     var filepath = testData + '/data/kml/1week_earthquake.kml';


### PR DESCRIPTION
This resolves #59 by checking stats.size _before_ running fs.read

cc @millzpaugh @GretaCB 