### PR TITLE
Re-order checks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
+  "env": {
+      "es6": true
+  },
   "extends": "eslint-config-unstyled"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 1.0.3
+
+- Bugfix: Properly detect `tiff+gz` files [#62](https://github.com/mapbox/mapbox-file-sniff/pull/62)
+
 ## 1.0.2
 
-Add check for zero byte files [#59](https://github.com/mapbox/mapbox-file-sniff/issues/59)
+- Add check for zero byte files [#59](https://github.com/mapbox/mapbox-file-sniff/issues/59)
 
 ## 1.0.1
 

--- a/index.js
+++ b/index.js
@@ -167,8 +167,6 @@ function detect(buffer, callback) {
       });
 }
 
-
-
 function getProtocol(type) {
     var mapping = {
         csv: 'omnivore:',

--- a/index.js
+++ b/index.js
@@ -48,95 +48,124 @@ function fromFile(file, callback) {
     });
 }
 
-function detect(buffer, callback) {
-    var header = buffer.toString().substring(0, 400);
 
-    // check for topojson/geojson
-    if (header.trim().indexOf('{') == 0) {
+function returnOutput(output) {
+    //check for tm2z
+    if (output.toString('ascii', 257, 262) === 'ustar') return 'tm2z';
 
-        // Remove spaces
-        var str = JSON.stringify(header);
-        var nospaces = str.replace(/\s/g, '');
-        header = JSON.parse(nospaces);
+    //check for serial tiles
+    const head = output.slice(0, 50);
+    if (head.toString().indexOf('JSONBREAKFASTTIME') === 0) return 'serialtiles';
 
-        if (header.indexOf('\"tilejson\":') !== -1) return callback(null, 'tilejson');
-        if ((header.indexOf('\"arcs\":') !== -1) || (header.indexOf('\"objects\":') !== -1)) return callback(null, 'topojson');
-        if ((header.indexOf('\"features\":') !== -1) || (header.indexOf('\"geometries\":') !== -1) || (header.indexOf('\"coordinates\":') !== -1)) return callback(null, 'geojson');
-        if (header.indexOf('\"type\":') !== -1) {
-            var m = /"type":\s?"(.+?)"/.exec(header);
-            if (!m) {
-                return callback(invalid('Unknown filetype'));
-            }
-            if (m[1] === 'Topology') return callback(null, 'topojson');
-            if (m[1] === 'Feature' ||
-                m[1] === 'FeatureCollection' ||
-                m[1] === 'Point' ||
-                m[1] === 'MultiPoint' ||
-                m[1] === 'LineString' ||
-                m[1] === 'MultiLineString' ||
-                m[1] === 'Polygon' ||
-                m[1] === 'MultiPolygon' ||
-                m[1] === 'GeometryCollection') return callback(null, 'geojson');
-        }
-        return callback(invalid('Unknown filetype'));
+    //check for tif+gz
+    if (
+        (output.slice(0, 2).toString() === 'II' || output.slice(0, 2).toString() === 'MM')
+        && ((output[2] === 42) || output[3] === 42 || output[2] === 43)) {
+        return 'tif+gz';
     }
 
-    var head = header.substring(0, 100);
-    if (head.indexOf('SQLite format 3') === 0) {
-        return callback(null, 'mbtiles');
-    }
-    if ((head[0] + head[1]) === 'PK') {
-        return callback(null, 'zip');
-    }
-    // check if geotiff/bigtiff
-    // matches gdal validation logic: https://github.com/OSGeo/gdal/blob/trunk/gdal/frmts/gtiff/geotiff.cpp#L6892-L6893
-    if ((head.slice(0, 2).toString() === 'II' || head.slice(0, 2).toString() === 'MM') && ((buffer[2] === 42) || buffer[3] === 42 || buffer[2] === 43)) {
-        return callback(null, 'tif');
-    }
-    // take into account BOM char at index 0
-    if (((head.indexOf('<?xml') === 1) || (head.indexOf('<?xml') === 0)) && (head.indexOf('<kml') !== -1)) {
-        return callback(null, 'kml');
-    }
-    // take into account BOM char at index 0
-    if (((head.indexOf('<?xml') === 1) || (head.indexOf('<?xml') === 0)) && (head.indexOf('<gpx') !== -1)) {
-        return callback(null, 'gpx');
-    }
-    if (head.indexOf('<VRTDataset') !== -1) {
-        return callback(null, 'vrt');
-    }
-    // check for unzipped .shp
-    if (buffer.length > 32 && buffer.readUInt32BE(0) === 9994) {
-        return callback(null, 'shp');
-    }
-
-    // Check for geocsv
-    if (isgeocsv(buffer)) {
-        return callback(null, 'csv');
-    }
-
-    function returnOutput(output,callback) {
-        //check for tm2z
-        if (output.toString('ascii', 257, 262) === 'ustar') return callback(null, 'tm2z');
-        //check for serial tiles
-        head = output.slice(0, 50);
-        if (head.toString().indexOf('JSONBREAKFASTTIME') === 0) return callback(null, 'serialtiles');
-
-        if (
-            (output.slice(0, 2).toString() === 'II' || output.slice(0, 2).toString() === 'MM')
-            && ((output[2] === 42) || output[3] === 42 || output[2] === 43)) {
-            return callback(null, 'tif+gz');
-        }
-
-        //default to unknown
-        return callback(invalid('Unknown filetype'));
-    }
-
-    var zlib_opts = {finishFlush: zlib.Z_SYNC_FLUSH };
-    zlib.gunzip(buffer, zlib_opts, function(err, output) {
-      if (err) return callback(invalid('Unknown filetype'));
-      returnOutput(output, callback);
-    });
+    //default to unknown
+    throw invalid('Unknown filetype');
 }
+
+/**
+ * promisify zlib.gunzip.
+ *
+ * @param {buffer} buffer -
+ * @returns {promise}
+ */
+
+function gunzipPromise (buffer) {
+
+    if (buffer.Body) buffer = buffer.Body;
+
+    return new Promise((resolve, reject) => {
+        zlib.gunzip(buffer, {finishFlush: zlib.Z_SYNC_FLUSH }, (err, data) => {
+            if (err) return reject(err);
+            return resolve(data);
+        });
+    });
+};
+
+function detect(buffer, callback) {
+
+    gunzipPromise(buffer)
+      .then(data => {
+          return returnOutput(data);
+      })
+      .then(type => {
+        return callback(null, type);
+      })
+      .catch(() => {
+
+        var header = buffer.toString().substring(0, 400);
+
+        // check for topojson/geojson
+        if (header.trim().indexOf('{') == 0) {
+
+            // Remove spaces
+            var str = JSON.stringify(header);
+            var nospaces = str.replace(/\s/g, '');
+            header = JSON.parse(nospaces);
+
+            if (header.indexOf('\"tilejson\":') !== -1) return callback(null, 'tilejson');
+            if ((header.indexOf('\"arcs\":') !== -1) || (header.indexOf('\"objects\":') !== -1)) return callback(null, 'topojson');
+            if ((header.indexOf('\"features\":') !== -1) || (header.indexOf('\"geometries\":') !== -1) || (header.indexOf('\"coordinates\":') !== -1)) return callback(null, 'geojson');
+            if (header.indexOf('\"type\":') !== -1) {
+                var m = /"type":\s?"(.+?)"/.exec(header);
+                if (!m) {
+                    return callback(invalid('Unknown filetype'));
+                }
+                if (m[1] === 'Topology') return callback(null, 'topojson');
+                if (m[1] === 'Feature' ||
+                    m[1] === 'FeatureCollection' ||
+                    m[1] === 'Point' ||
+                    m[1] === 'MultiPoint' ||
+                    m[1] === 'LineString' ||
+                    m[1] === 'MultiLineString' ||
+                    m[1] === 'Polygon' ||
+                    m[1] === 'MultiPolygon' ||
+                    m[1] === 'GeometryCollection') return callback(null, 'geojson');
+            }
+            return callback(invalid('Unknown filetype'));
+        }
+
+        var head = header.substring(0, 100);
+        if (head.indexOf('SQLite format 3') === 0) {
+            return callback(null, 'mbtiles');
+        }
+        if ((head[0] + head[1]) === 'PK') {
+            return callback(null, 'zip');
+        }
+        // check if geotiff/bigtiff
+        // matches gdal validation logic: https://github.com/OSGeo/gdal/blob/trunk/gdal/frmts/gtiff/geotiff.cpp#L6892-L6893
+        if ((head.slice(0, 2).toString() === 'II' || head.slice(0, 2).toString() === 'MM') && ((buffer[2] === 42) || buffer[3] === 42 || buffer[2] === 43)) {
+            return callback(null, 'tif');
+        }
+        // take into account BOM char at index 0
+        if (((head.indexOf('<?xml') === 1) || (head.indexOf('<?xml') === 0)) && (head.indexOf('<kml') !== -1)) {
+            return callback(null, 'kml');
+        }
+        // take into account BOM char at index 0
+        if (((head.indexOf('<?xml') === 1) || (head.indexOf('<?xml') === 0)) && (head.indexOf('<gpx') !== -1)) {
+            return callback(null, 'gpx');
+        }
+        if (head.indexOf('<VRTDataset') !== -1) {
+            return callback(null, 'vrt');
+        }
+        // check for unzipped .shp
+        if (buffer.length > 32 && buffer.readUInt32BE(0) === 9994) {
+            return callback(null, 'shp');
+        }
+
+        // Check for geocsv
+        if (isgeocsv(buffer)) {
+            return callback(null, 'csv');
+        }
+      })
+}
+
+
 
 function getProtocol(type) {
     var mapping = {

--- a/index.js
+++ b/index.js
@@ -96,8 +96,7 @@ function detect(buffer, callback) {
       .then(type => {
         return callback(null, type);
       })
-      .catch(() => {
-
+      .catch((err) => {
         var header = buffer.toString().substring(0, 400);
 
         // check for topojson/geojson
@@ -162,7 +161,10 @@ function detect(buffer, callback) {
         if (isgeocsv(buffer)) {
             return callback(null, 'csv');
         }
-      })
+
+        // If not one of the test are valie then return "Unknown"
+        return callback(invalid('Unknown filetype'));
+      });
 }
 
 


### PR DESCRIPTION
closes #61 

This PR re-order the checks to make sure we don't run `isgeocsv` on a gzip buffer string. 

I did a bit of a refactor and add a *Promised* gunzip function to keep the code as clear as possible. This also mean the module will be compatible only with >es6 I think (but I might be wrong.

cc @GretaCB @mapsam 