### PR TITLE
Remove unneeded magic number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Bugfix: Remove unneeded "deflate" magic number [#63](https://github.com/mapbox/mapbox-file-sniff/pull/63)
+
 ## 1.0.3
 
 - Bugfix: Properly detect `tiff+gz` files [#62](https://github.com/mapbox/mapbox-file-sniff/pull/62)

--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ function gunzipPromise (buffer) {
  */
 function isGzip (buffer) {
     return buffer[0] === 0x1F
-        && buffer[1] === 0x8B
-        && buffer[2] === 0x08;
+        && buffer[1] === 0x8B;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-file-sniff",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Detects type of spatial file",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Turns out the third magic number currently used to validate `gzip`'d files is used to [denote the "deflate" compression method](http://www.zlib.org/rfc-gzip.html#header-trailer) (to tell if a deflated file was gunzipped), and is not what `isGzip` should be concerned about.

Curious how this was still effectively detecting `tif+gz`, `tm2z` and `serialtiles` in the unit tests.

cc @vincentsarago @springmeyer @mapsam 